### PR TITLE
Add odh ns, operator, and kfdef for JH.

### DIFF
--- a/manifests/.pre-commit-config.yaml
+++ b/manifests/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+---
+exclude: scripts|argocd/overlays/dev/configs|argocd/overlays/moc-infra/configs
+
+repos:
+  - repo: git://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.9
+    hooks:
+      - id: remove-tabs
+
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v3.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-symlinks
+      - id: detect-private-key
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.25.0
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]
+        entry: yamllint --strict -c manifests/yamllint-config.yaml

--- a/manifests/cluster_resources/base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org/customresourcedefinition.yaml
+++ b/manifests/cluster_resources/base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org/customresourcedefinition.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kfdefs.kfdef.apps.kubeflow.org
+spec:
+  group: kfdef.apps.kubeflow.org
+  names:
+    kind: KfDef
+    listKind: KfDefList
+    plural: kfdefs
+    singular: kfdef
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KfDef is the Schema for the kfdefs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KfDefSpec defines the desired state of KfDef
+          type: object
+        status:
+          description: KfDefStatus defines the observed state of KfDef
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/manifests/cluster_resources/base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org/kustomization.yaml
+++ b/manifests/cluster_resources/base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- customresourcedefinition.yaml

--- a/manifests/cluster_resources/base/core/namespaces/odh-jupyterhub/kustomization.yaml
+++ b/manifests/cluster_resources/base/core/namespaces/odh-jupyterhub/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+- ../../../../components/project-admin-rolebindings/odh-admin
+- ../../../../components/monitoring-rbac
+kind: Kustomization
+namespace: odh-jupyterhub
+resources:
+- namespace.yaml

--- a/manifests/cluster_resources/base/core/namespaces/odh-jupyterhub/namespace.yaml
+++ b/manifests/cluster_resources/base/core/namespaces/odh-jupyterhub/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OS-C Climate: JupyterHub"
+  name: odh-jupyterhub
+spec: {}

--- a/manifests/cluster_resources/base/core/namespaces/opendatahub-operator/kustomization.yaml
+++ b/manifests/cluster_resources/base/core/namespaces/opendatahub-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+- ../../../../components/monitoring-rbac
+- ../../../../components/project-admin-rolebindings/odh-admin
+kind: Kustomization
+namespace: opendatahub-operator
+resources:
+- namespace.yaml

--- a/manifests/cluster_resources/base/core/namespaces/opendatahub-operator/namespace.yaml
+++ b/manifests/cluster_resources/base/core/namespaces/opendatahub-operator/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OS-C Climate: Opendatahub operator"
+  name: opendatahub-operator
+spec: {}

--- a/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator/clusterrolebinding.yaml
+++ b/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opendatahub-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opendatahub-operator
+subjects:
+- kind: ServiceAccount
+  name: opendatahub-operator
+  namespace: opendatahub-operator

--- a/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator/kustomization.yaml
+++ b/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterroles/opendatahub-operator/clusterrole.yaml
+++ b/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterroles/opendatahub-operator/clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: opendatahub-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'

--- a/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterroles/opendatahub-operator/kustomization.yaml
+++ b/manifests/cluster_resources/base/rbac.authorization.k8s.io/clusterroles/opendatahub-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/manifests/cluster_resources/base/user.openshift.io/groups/odh-admin/group.yaml
+++ b/manifests/cluster_resources/base/user.openshift.io/groups/odh-admin/group.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: odh-admin
+users: []

--- a/manifests/cluster_resources/base/user.openshift.io/groups/odh-admin/kustomization.yaml
+++ b/manifests/cluster_resources/base/user.openshift.io/groups/odh-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- group.yaml

--- a/manifests/cluster_resources/components/monitoring-rbac/kustomization.yaml
+++ b/manifests/cluster_resources/components/monitoring-rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - monitoring-role.yaml
+  - monitoring-rolebinding.yaml

--- a/manifests/cluster_resources/components/monitoring-rbac/monitoring-role.yaml
+++ b/manifests/cluster_resources/components/monitoring-rbac/monitoring-role.yaml
@@ -1,0 +1,22 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-monitoring
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - configmaps

--- a/manifests/cluster_resources/components/monitoring-rbac/monitoring-rolebinding.yaml
+++ b/manifests/cluster_resources/components/monitoring-rbac/monitoring-rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: odh-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-monitoring

--- a/manifests/cluster_resources/components/project-admin-rolebindings/odh-admin/kustomization.yaml
+++ b/manifests/cluster_resources/components/project-admin-rolebindings/odh-admin/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./rbac.yaml

--- a/manifests/cluster_resources/components/project-admin-rolebindings/odh-admin/rbac.yaml
+++ b/manifests/cluster_resources/components/project-admin-rolebindings/odh-admin/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin-odh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: odh-admin

--- a/manifests/cluster_resources/overlays/prod/aws-us-east-1/common/kustomization.yaml
+++ b/manifests/cluster_resources/overlays/prod/aws-us-east-1/common/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common

--- a/manifests/cluster_resources/overlays/prod/aws-us-east-1/odh-cl1/kustomization.yaml
+++ b/manifests/cluster_resources/overlays/prod/aws-us-east-1/odh-cl1/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../common
+  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org
+  - ../../../../base/core/namespaces/opendatahub-operator
+  - ../../../../base/core/namespaces/odh-jupyterhub
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterroles/opendatahub-operator

--- a/manifests/cluster_resources/overlays/prod/common/groups/odh-admin.yaml
+++ b/manifests/cluster_resources/overlays/prod/common/groups/odh-admin.yaml
@@ -1,0 +1,7 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: odh-admin
+users:
+    - hukhan
+    - mmikhail

--- a/manifests/cluster_resources/overlays/prod/common/kustomization.yaml
+++ b/manifests/cluster_resources/overlays/prod/common/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/user.openshift.io/groups/odh-admin
+
+patchesStrategicMerge:
+  - groups/odh-admin.yaml

--- a/manifests/kfdefs/jupyterhub/kfdef.yaml
+++ b/manifests/kfdefs/jupyterhub/kfdef.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: jupyterhub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: jupyterhub/jupyterhub
+      name: jupyterhub
+    - kustomizeConfig:
+        overlays:
+          - additional
+        repoRef:
+          name: manifests
+          path: jupyterhub/notebook-images
+      name: notebook-images
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: radanalyticsio/spark/cluster
+      name: radanalyticsio-spark-cluster
+  repos:
+    - name: manifests
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.0"
+  version: v1.1.0

--- a/manifests/kfdefs/jupyterhub/kustomization.yaml
+++ b/manifests/kfdefs/jupyterhub/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: odh-jupyterhub
+resources:
+  - kfdef.yaml

--- a/manifests/odh-operator/deployment.yaml
+++ b/manifests/odh-operator/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opendatahub-operator
+  namespace: openshift-operators
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: opendatahub-operator
+  template:
+    metadata:
+      labels:
+        name: opendatahub-operator
+    spec:
+      containers:
+      - command:
+        - opendatahub-operator
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/opendatahub/opendatahub-operator:v1.0.4
+        imagePullPolicy: Always
+        name: opendatahub-operator
+      serviceAccountName: opendatahub-operator

--- a/manifests/odh-operator/kustomization.yaml
+++ b/manifests/odh-operator/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub-operator
+
+# Source: https://github.com/opendatahub-io/opendatahub-operator/tree/master/kustomize/overlays/opendatahub
+resources:
+- deployment.yaml
+- serviceaccount.yaml
+
+images:
+- name: quay.io/opendatahub/opendatahub-operator
+  newTag: v1.1.0

--- a/manifests/odh-operator/serviceaccount.yaml
+++ b/manifests/odh-operator/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opendatahub-operator
+  namespace: openshift-operators

--- a/manifests/yamllint-config.yaml
+++ b/manifests/yamllint-config.yaml
@@ -1,0 +1,9 @@
+---
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  indentation:
+    indent-sequences: whatever
+  hyphens:
+    max-spaces-after: 4


### PR DESCRIPTION
This pr does the following: 
- adds the `cluster-resources` directory, where all cluster admin level resources will be stored (also adds the odh and JH namespace)
- adds an `odh-admin` ocp group, users belonging to this group will be able to acces odh namespaces at the admin level
- adds the manual installation for the odh operator 
- adds the kfdef to deploy jupyterhub
- adds some pre-commit linting config files

These manifests have already been deployed on the cluster manually. 

As you can see I'm not using OLM to install ODH, since that introduces additional rbac that let's any project admin deploy a kfdef (which in effect allows any one with project admin to take over the cluster, we discuss this in operate-first [here](https://github.com/operate-first/apps/issues/206)).

I also deployed JH to it's own namespace (again, this is reflective of our operate-first deployment). Other ODH components will come with their own kfdefs.  