### PR TITLE
Enable JH access for authenticated

### DIFF
--- a/manifests/odh-manifests/jupyterhub/base/jupyterhub-groups-configmap.yaml
+++ b/manifests/odh-manifests/jupyterhub/base/jupyterhub-groups-configmap.yaml
@@ -7,3 +7,4 @@ metadata:
   name: jupyterhub-default-groups-config
 data:
   admin_groups: "odh-admin"
+  allowed_groups: "system:authenticated"


### PR DESCRIPTION
This should allow anyone that authenticates via the cluster access to the JH environment. We can in the future scope access further if needed. 