### PR TITLE
add example credentials.env

### DIFF
--- a/docs/credentials.env
+++ b/docs/credentials.env
@@ -1,0 +1,16 @@
+# user trino credentials
+# Get your JWT token from:
+# old: https://das-odh-trino.apps.odh-cl1.apps.os-climate.org
+# new: https://das-odh-trino.apps.odh-cl2.apps.os-climate.org
+TRINO_HOST=trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org
+TRINO_PORT=443
+TRINO_USER=your_github_username
+TRINO_PASSWD=your_passwd_or_jwt_token
+
+# creds for 'osc physical landing' bucket
+# for OSC landing bucket credentials, file an issue at:
+# https://github.com/os-climate/OS-Climate-Community-Hub
+S3_LANDING_ENDPOINT=https://s3.us-east-1.amazonaws.com
+S3_LANDING_BUCKET=redhat-osc-physical-landing-647521352890
+S3_LANDING_ACCESS_KEY=on_request
+S3_LANDING_SECRET_KEY=on_request


### PR DESCRIPTION
Signed-off-by: Erik Erlandson <eerlands@redhat.com>

Anyone not needing physical landing bucket can just copy this directly into their JH env without screwing around with
safenote or otherwise waiting for me or someone else to send it