### PR TITLE
Update profiles.yml

### DIFF
--- a/docs/profiles.yml
+++ b/docs/profiles.yml
@@ -4,10 +4,10 @@ dbt_project_name:
     dev:
       type: trino
       method: jwt
-      user: user_name
-      jwt_token: jwt_token
+      user: "{{ env_var('TRINO_USER') }}"
+      jwt_token: "{{ env_var('TRINO_PASSWD') }}"
       database: osc_datacommons_dev
-      host: trino-secure-odh-trino.apps.odh-cl2.apps.os-climate.org
-      port: 443
+      host: "{{ env_var('TRINO_HOST') }}"
+      port: "{{ env_var('TRINO_PORT') }}"
       schema: dbt_project_name
       threads: 1


### PR DESCRIPTION
There are a number of Data Commons-specific parameters and secrets defined in the `credentials.env` file.  The example file now shows how these parameters can be accessed using the env_var functionality of YAML files.  This has the benefit that when a user is managing a number of dbt projects over a period of time, they won't have to update things like the `jwt_token` several times every few days (which gets old quickly).  It has the nice side effect that the `profiles.yml` file no longer contains any secrets.